### PR TITLE
Remove syslinux package

### DIFF
--- a/build-centos-iso/new-iso.sh
+++ b/build-centos-iso/new-iso.sh
@@ -64,7 +64,6 @@ net-tools
 parted
 shadow-utils
 shim
-syslinux
 python-setuptools
 %end
 EOF


### PR DESCRIPTION
This package was causing the installer to prompt the user for action
because the package itself doesn't exist